### PR TITLE
Feat: Recuperar Senha (envio de email)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^5.1.0",
         "express-session": "^1.18.1",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^7.0.2",
         "uuid": "^11.1.0",
         "zod": "^3.24.3"
       },
@@ -26,6 +27,7 @@
         "@types/bcrypt": "^5.0.2",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/node": "^22.15.3",
+        "@types/nodemailer": "^6.4.17",
         "prisma": "^6.6.0",
         "typescript": "^5.8.3"
       }
@@ -665,6 +667,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -1763,6 +1775,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.2.tgz",
+      "integrity": "sha512-SYsisPeLFYli5Q+BCGSyHT5CVvezPmQjHgINV9KVvVLV1aktuoD4E0Np9Q3ND9I481qIHzUQzVT+Tl/Tw7Ivdg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nopt": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/bcrypt": "^5.0.2",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/node": "^22.15.3",
+    "@types/nodemailer": "^6.4.17",
     "prisma": "^6.6.0",
     "typescript": "^5.8.3"
   },
@@ -30,6 +31,7 @@
     "express": "^5.1.0",
     "express-session": "^1.18.1",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^7.0.2",
     "uuid": "^11.1.0",
     "zod": "^3.24.3"
   }

--- a/src/application/dto/UserEmailDTO.ts
+++ b/src/application/dto/UserEmailDTO.ts
@@ -1,0 +1,7 @@
+export class UserEmailDTO{
+    public email: string;
+
+    constructor(email:string){
+        this.email = email;
+    }
+}

--- a/src/application/usecases/RecuperarSenha.ts
+++ b/src/application/usecases/RecuperarSenha.ts
@@ -1,0 +1,37 @@
+import { IJwtConfig } from "../../infrastructure/utils/jwt/IJwtConfig";
+import { IMailer } from "../../infrastructure/utils/nodemailer/IMailer";
+import { IResetPasswordEmail } from "../../infrastructure/utils/nodemailer/recuperarSenhaMail/IResetPasswordEmail";
+import { UserEmailDTO } from "../dto/UserEmailDTO";
+import { IUserRepository } from "./repositories/IUserRepository";
+
+export class RecuperarSenha {
+  constructor(
+    private userRepository: IUserRepository,
+    private mailer: IMailer,
+    private jwtConfig: IJwtConfig,
+    private mailerTemplate: IResetPasswordEmail
+  ) {}
+
+  public async execute(dto: UserEmailDTO): Promise<void> {
+    const userValidation = await this.userRepository.validate(dto.email);
+
+    if (!userValidation) {
+      throw new Error("[Usuário não encontrado no banco de dados]");
+    }
+
+    const token = this.jwtConfig.sign(
+      { id: userValidation.id, email: userValidation.email },
+      { expiresIn: "15m" }
+    );
+
+    const url = `http://localhost:4000/users/redefinirSenha??token=${token}`;
+
+    const html = this.mailerTemplate.generate(url);
+
+    this.mailer
+      .sendMail(dto.email, "Recuperação de senha", html)
+      .catch((err) => {
+        console.error("[Erro ao enviar e-mail de recuperação de senha]", err);
+      });
+  }
+}

--- a/src/infrastructure/env/envConfig.ts
+++ b/src/infrastructure/env/envConfig.ts
@@ -5,3 +5,9 @@ dotenv.config({ path: path.resolve(__dirname, ".env") });
 
 export const DATABASE_URL = process.env.DATABASE_URL;
 export const PORT = process.env.PORT || 3000;   
+export const SMTP_HOST = process.env.SMTP_HOST;
+export const SMTP_PORT = process.env.SMTP_PORT || 587;
+export const SMTP_USER = process.env.SMTP_USER;
+export const SMTP_PASS = process.env.SMTP_PASS;
+export const SECRET_KEY = process.env.SECRET_KEY;
+export const SESSION_SECRET = process.env.SESSION_SECRET;

--- a/src/infrastructure/factories/UserFactory.ts
+++ b/src/infrastructure/factories/UserFactory.ts
@@ -11,18 +11,45 @@ import { PrismaConfig } from "../database/PrismaConfig";
 import { Login } from "../../application/usecases/Login";
 import { IJwtConfig } from "../utils/jwt/IJwtConfig";
 import { JwtConfig } from "../utils/jwt/JwtConfig";
+import { SECRET_KEY } from "../env/envConfig";
+import { RecuperarSenha } from "../../application/usecases/RecuperarSenha";
+import { IMailer } from "../utils/nodemailer/IMailer";
+import Mailer from "../utils/nodemailer/Mailer";
+import { IResetPasswordEmail } from "../utils/nodemailer/recuperarSenhaMail/IResetPasswordEmail";
+import { ResetPasswordEmail } from "../utils/nodemailer/recuperarSenhaMail/ResetPasswordEmail";
 
 
 
 export function UserFactory(): UserController {
     const prismaConfig: IPrismaConfig = new PrismaConfig();
-    const secretKey = process.env.SECRET_KEY as string;
+    const secretKey = SECRET_KEY as string;
     const userRepository: IUserRepository = new UserRepository(prismaConfig);
     const bcryptConfig: IBcryptConfig = new BcryptConfig();
     const uuidConfig: IUuidConfig = new UuidConfig();
     const jwtConfig: IJwtConfig = new JwtConfig(secretKey);
- 
-    const createUserUseCase = new CreateUser(userRepository, bcryptConfig, uuidConfig); // Use Case recebe a interface
-    const loginUseCase = new Login(userRepository, bcryptConfig, jwtConfig)
-    return new UserController(createUserUseCase, loginUseCase); // Controller recebe os Use Cases
+    const mailer: IMailer = new Mailer();
+    const mailerTemplate: IResetPasswordEmail = new ResetPasswordEmail
+    
+    const recuperarSenhaUseCase = new RecuperarSenha(
+        userRepository, 
+        mailer, 
+        jwtConfig, 
+        mailerTemplate
+    );
+    const createUserUseCase = new CreateUser(
+        userRepository, 
+        bcryptConfig, 
+        uuidConfig
+    );
+    const loginUseCase = new Login(
+        userRepository, 
+        bcryptConfig, 
+        jwtConfig
+    );
+
+    return new UserController(
+        createUserUseCase, 
+        loginUseCase, 
+        recuperarSenhaUseCase
+    ); // Controller recebe os Use Cases
 }

--- a/src/infrastructure/utils/nodemailer/IMailer.ts
+++ b/src/infrastructure/utils/nodemailer/IMailer.ts
@@ -1,0 +1,4 @@
+export interface IMailer {
+    sendMail(to: string, subject: string, html: string): Promise<void>;
+}
+  

--- a/src/infrastructure/utils/nodemailer/Mailer.ts
+++ b/src/infrastructure/utils/nodemailer/Mailer.ts
@@ -1,0 +1,32 @@
+import nodemailer from 'nodemailer';
+import { Transporter } from 'nodemailer';
+import { SMTP_HOST, SMTP_PASS, SMTP_PORT, SMTP_USER } from '../../env/envConfig'
+import { IMailer } from './IMailer';
+
+class Mailer implements IMailer {
+  private transporter: Transporter;
+
+  constructor() {
+    this.transporter = nodemailer.createTransport({
+      host: SMTP_HOST,
+      port: Number(SMTP_PORT),
+      secure: false,
+      auth: {
+        user: SMTP_USER,
+        pass: SMTP_PASS,
+      },
+    });
+  }
+
+  public async sendMail(to: string, subject: string, html: string): Promise<void> {
+    await this.transporter.sendMail({
+      from: `"Easy English" <${SMTP_USER}>`,
+      to,
+      subject,
+      html,
+    });
+  }
+
+}
+
+export default Mailer;

--- a/src/infrastructure/utils/nodemailer/recuperarSenhaMail/IResetPasswordEmail.ts
+++ b/src/infrastructure/utils/nodemailer/recuperarSenhaMail/IResetPasswordEmail.ts
@@ -1,0 +1,4 @@
+export interface IResetPasswordEmail {
+    generate(url: string): string;
+}
+  

--- a/src/infrastructure/utils/nodemailer/recuperarSenhaMail/ResetPasswordEmail.ts
+++ b/src/infrastructure/utils/nodemailer/recuperarSenhaMail/ResetPasswordEmail.ts
@@ -1,0 +1,55 @@
+import { IResetPasswordEmail } from "./IResetPasswordEmail";
+
+export class ResetPasswordEmail implements IResetPasswordEmail {
+  public generate(url: string): string {
+    return `
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Recuperação de Senha</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f6f6f6;
+      padding: 20px;
+    }
+    .container {
+      max-width: 600px;
+      margin: auto;
+      background: #ffffff;
+      padding: 30px;
+      border-radius: 6px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .button {
+      display: inline-block;
+      padding: 12px 20px;
+      margin-top: 20px;
+      background-color: #007bff;
+      color: #ffffff;
+      text-decoration: none;
+      border-radius: 4px;
+      font-weight: bold;
+    }
+    .small {
+      font-size: 12px;
+      color: #666666;
+      margin-top: 30px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>Recuperação de Senha</h2>
+    <p>Você solicitou a redefinição de sua senha. Clique no botão abaixo para criar uma nova senha. Este link é válido por tempo limitado e só pode ser usado uma vez.</p>
+    
+    <a href="${url}" class="button">Redefinir Senha</a>
+    
+    <p class="small">Se você não solicitou essa alteração, ignore este e-mail. Sua senha atual permanecerá a mesma.</p>
+  </div>
+</body>
+</html>
+    `;
+  }
+}

--- a/src/infrastructure/utils/zod/validateDTOUserEmail.ts
+++ b/src/infrastructure/utils/zod/validateDTOUserEmail.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export async function validateDTOUserEmail(reqSchema: Object, res: any) {
+  const userSchema = z.object({
+    email: z.string().email("[Formato de email inválido]")
+  });
+
+  try {
+    const user = userSchema.parse(reqSchema);
+    return user;
+  } catch (error: any) {
+    if (error instanceof z.ZodError) {
+      const errorMessages = error.errors.map((err: any) => ({
+        path: err.path.join('.'),
+        message: err.message,
+      }));
+      console.error("Erro de validação:", JSON.stringify(errorMessages, null, 2));
+    } else {
+      console.error("Erro desconhecido:", error);
+    }
+    throw new Error("Dados inválidos");
+  }
+}

--- a/src/infrastructure/web/app.ts
+++ b/src/infrastructure/web/app.ts
@@ -6,6 +6,7 @@ import { userRouter } from './routes/user';
 import { adminRouter } from './routes/admin';
 import { studentRouter } from './routes/student';
 import cors from 'cors';
+import { SESSION_SECRET } from '../env/envConfig';
 
 const app: Application = express();
 
@@ -13,7 +14,7 @@ const app: Application = express();
 app.use(cors());
 
 app.use(session({
-    secret: process.env.SESSION_SECRET as string,
+    secret: SESSION_SECRET as string,
     resave: false,
     saveUninitialized: true,            
     cookie: { secure: false }

--- a/src/infrastructure/web/controllers/UserController.ts
+++ b/src/infrastructure/web/controllers/UserController.ts
@@ -5,18 +5,24 @@ import { CreateUser } from '../../../application/usecases/CreateUser';
 import { UserLoginDTO } from '../../../application/dto/UserLoginDTO';
 import { Login } from '../../../application/usecases/Login';
 import { validateDTOLogin } from '../../utils/zod/validateDTOLogin';
+import { validateDTOUserEmail } from '../../utils/zod/validateDTOUserEmail';
+import { UserEmailDTO } from '../../../application/dto/UserEmailDTO';
+import { RecuperarSenha } from '../../../application/usecases/RecuperarSenha';
 
 
 export class UserController {
     private createUserUseCase: CreateUser
     private loginUseCase: Login
+    private recuperarSenhaUseCase: RecuperarSenha
 
     constructor(
         createUserUseCase: CreateUser,
-        loginUseCase: Login
+        loginUseCase: Login,
+        recuperarSenhaUseCase: RecuperarSenha
     ) {
         this.createUserUseCase = createUserUseCase;
-        this.loginUseCase = loginUseCase;
+        this.loginUseCase = loginUseCase; 
+        this.recuperarSenhaUseCase = recuperarSenhaUseCase;
     }
 
     public async create(req: Request, res: Response): Promise<any> {
@@ -75,6 +81,30 @@ export class UserController {
         } catch (error) {
             console.error('Erro ao processar requisição:', error);
             res.status(400).json({ message: `Erro realizar Login - ${error}` });
+        }
+    }
+
+    public async recuperarSenha(req: Request, res: Response): Promise<any>{
+        try {
+            
+            const {email} = req.body;
+
+            const reqSchema = {email};
+
+            const validatedData = await validateDTOUserEmail(reqSchema, res);
+            if (!validatedData) return;
+
+            const dto = new UserEmailDTO(validatedData.email);
+
+            const userResponse = await this.recuperarSenhaUseCase.execute(dto);
+
+            res.status(201).json({
+                message: "Email enviado!",
+            });
+
+        } catch (error) {
+            console.error('Erro ao processar requisição:', error);
+            res.status(400).json({ message: `Erro ao Recuperar Senha - ${error}` });
         }
     }
 }

--- a/src/infrastructure/web/routes/user.ts
+++ b/src/infrastructure/web/routes/user.ts
@@ -11,4 +11,7 @@ userRouter.post('/cadastro', (req, res) => userController.create(req, res));
 //rota para login
 userRouter.post('/login', (req, res) => userController.login(req, res));
 
+//rota de recuperação de senha
+userRouter.post('/recuperarSenha', (req, res) => userController.recuperarSenha(req, res));
+
 export { userRouter };


### PR DESCRIPTION
Implementa a funcionalidade de **recuperar senha** com as responsabilidades separadas em:

- DTOs;
- Entidades;  
- Casos de Uso (UseCase);  
- Repositórios;
- Factories;  
- Controllers;  
- Rotas;
- Dependências;  

Foi utilizado `nodemailer` para envio de emails.
---

## ✅ O que foi feito

- [x] Alteração do Repositório `UserRepository` na pasta repositories;
- [x] Criação do DTO `UserEmailDTO` ;
- [x] Caso de uso `RecuperarSenha` com regras de negócio;
- [x] Alteração da Factory para instanciar as camadas;
- [x] Controller e rota para `/users/recuperarSenhs`;
- [x] Integração com `nodemailer`;
- [x] Estrutura do email com `nodemailer`; 

---

## 📦 Dependências novas

```bash
npm install nodemailer
```

---

##  Regras de negócio aplicadas

- [x] Email deve ser único e possuir formato de um email; 
- [x] Email deve estar no banco de dados;

---

## Como testar

POST /users/cadastro

```json
{
  "email": "email.teste@gmail.com"
}

```
---

## 🔜 Próximos Passos

- [ ] Adicionar testes unitários;  
- [x] Criar endpoint(rota) de autenticação (redefinirSenha).



