### PR TITLE
Fix: Responder Questao agora salva progresso

### DIFF
--- a/src/application/dto/AnswerQuestionDTO.ts
+++ b/src/application/dto/AnswerQuestionDTO.ts
@@ -1,9 +1,15 @@
 export class AnswerQuestionDTO {
-    public id: string;
+    public questionId: string;
     public answer: string;
+    public userId: string;
   
-    constructor(id: string, answer: string) {
-      this.id = id;
+    constructor(
+      questionId: string, 
+      answer: string,
+      userId: string
+    ) {
+      this.questionId = questionId;
       this.answer = answer;
+      this.userId = userId
     }
 }

--- a/src/application/usecases/repositories/IUserQuestionProgressRepository.ts
+++ b/src/application/usecases/repositories/IUserQuestionProgressRepository.ts
@@ -1,0 +1,7 @@
+import { UserQuestionProgress } from "../../../domain/entities/UserQuestionProgress";
+
+export interface IUserQuestionProgressRepository {
+  create(userQuestionProgress: UserQuestionProgress): Promise<UserQuestionProgress>;
+  findByUserAndQuestion(userId: string, questionId: string): Promise<UserQuestionProgress | null>;
+  update(userQuestionProgress: UserQuestionProgress): Promise<UserQuestionProgress>;
+}

--- a/src/application/usecases/repositories/UserQuestionProgressRepository.ts
+++ b/src/application/usecases/repositories/UserQuestionProgressRepository.ts
@@ -1,0 +1,70 @@
+import { UserQuestionProgress } from "../../../domain/entities/UserQuestionProgress";
+import { IUserQuestionProgressRepository } from "./IUserQuestionProgressRepository";
+import { IPrismaConfig } from "../../../infrastructure/database/IPrismaConfig";
+
+export class UserQuestionProgressRepository implements IUserQuestionProgressRepository {
+    constructor(private prismaConfig: IPrismaConfig){}
+   
+    private get prisma(){
+        return this.prismaConfig.prisma
+    }
+
+    public async create(userQuestionProgress: UserQuestionProgress): Promise<UserQuestionProgress> {
+        const created = await this.prisma.userQuestionProgress.create({
+            data: {
+                id: userQuestionProgress.id,
+                userId: userQuestionProgress.userId,
+                questionId: userQuestionProgress.questionId,
+                status: userQuestionProgress.status,
+                chosenOption: userQuestionProgress.chosenOption
+            }
+        });
+    
+        return new UserQuestionProgress({
+            id: created.id,
+            userId: created.userId ?? undefined,
+            questionId: created.questionId ?? undefined,
+            status: created.status ?? undefined,
+            chosenOption: created.chosenOption ?? undefined,
+        });
+    }
+
+    public async findByUserAndQuestion(userId: string, questionId: string): Promise<UserQuestionProgress | null> {
+        const progress = await this.prisma.userQuestionProgress.findFirst({
+            where: { 
+                userId: userId,
+                questionId: questionId
+            }
+        });
+    
+        if (!progress) return null;
+    
+        return new UserQuestionProgress({
+            id: progress.id,
+            userId: progress.userId ?? undefined,
+            questionId: progress.questionId ?? undefined,
+            status: progress.status ?? undefined,
+            chosenOption: progress.chosenOption ?? undefined,
+        });
+    }
+
+    public async update(userQuestionProgress: UserQuestionProgress): Promise<UserQuestionProgress> {
+        const updated = await this.prisma.userQuestionProgress.update({
+            where: { id: userQuestionProgress.id },
+            data: {
+                userId: userQuestionProgress.userId,
+                questionId: userQuestionProgress.questionId,
+                status: userQuestionProgress.status,
+                chosenOption: userQuestionProgress.chosenOption
+            }
+        });
+    
+        return new UserQuestionProgress({
+            id: updated.id,
+            userId: updated.userId ?? undefined,
+            questionId: updated.questionId ?? undefined,
+            status: updated.status ?? undefined,
+            chosenOption: updated.chosenOption ?? undefined,
+        });
+    }
+}

--- a/src/infrastructure/factories/QuestionFactory.ts
+++ b/src/infrastructure/factories/QuestionFactory.ts
@@ -10,11 +10,14 @@ import { UpdateQuestion } from "../../application/usecases/UpdateQuestion";
 import { GetAllQuestions } from "../../application/usecases/GetAllQuestions";
 import { DeleteQuestion } from "../../application/usecases/DeleteQuestion";
 import { AnswerQuestion } from "../../application/usecases/AnswerQuestion";
+import { IUserQuestionProgressRepository } from "../../application/usecases/repositories/IUserQuestionProgressRepository";
+import { UserQuestionProgressRepository } from "../../application/usecases/repositories/UserQuestionProgressRepository";
 
 export function QuestionFactory(): QuestionController {
     const prismaConfig: IPrismaConfig = new PrismaConfig();
     const questionRepository: IQuestionRepository = new QuestionRepository(prismaConfig);
     const uuidConfig: IUuidConfig = new UuidConfig();
+    const userQuestionProgressRepository: IUserQuestionProgressRepository = new UserQuestionProgressRepository(prismaConfig);
 
     const createQuestionUseCase = new CreateQuestion(
         questionRepository,
@@ -34,7 +37,9 @@ export function QuestionFactory(): QuestionController {
     );
 
     const answerQuestionUseCase = new AnswerQuestion(
-        questionRepository
+        questionRepository,
+        userQuestionProgressRepository,
+        uuidConfig
     );
 
     return new QuestionController(

--- a/src/infrastructure/utils/uuid/IUuidConfig.ts
+++ b/src/infrastructure/utils/uuid/IUuidConfig.ts
@@ -2,4 +2,5 @@ export interface IUuidConfig {
     generateStudentId():Promise<string>;
     generateAdminId(): Promise<string>;
     generateQuestionId(): Promise<string>;
+    generateUserQuestionProgressId(): Promise<string>;
 }

--- a/src/infrastructure/utils/uuid/UuidConfig.ts
+++ b/src/infrastructure/utils/uuid/UuidConfig.ts
@@ -23,6 +23,13 @@ export class UuidConfig implements IUuidConfig{
         const uuidComPrefixo = "Q-" + uuidLimitado;
         return uuidComPrefixo;
     }
+
+    public async generateUserQuestionProgressId(): Promise<string> {
+        const uuid = uuidv4();
+        const uuidLimitado = uuid.substring(0, 12);
+        const uuidComPrefixo = "PROGRESS-" + uuidLimitado;
+        return uuidComPrefixo;
+    }
 }
 
 

--- a/src/infrastructure/utils/zod/validateDTOAnswerQuestion.ts
+++ b/src/infrastructure/utils/zod/validateDTOAnswerQuestion.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 
 export async function validateDTOAnswerQuestion(reqSchema: object, res: any) {
   const answerQuestionSchema = z.object({
-    id: z.string().min(1, "[ID é obrigatório]"),
+    userId: z.string().min(1, "[ID do usuário é obrigatório]"),
+    questionId: z.string().min(1, "[ID da questão é obrigatório]"),
     answer: z.string().min(1, "[Resposta é obrigatória]"),
   });
 

--- a/src/infrastructure/web/controllers/QuestionController.ts
+++ b/src/infrastructure/web/controllers/QuestionController.ts
@@ -140,13 +140,15 @@ export class QuestionController {
 
   public async answerQuestion(req: Request, res: Response): Promise<any> {
     try {
-      const { id, answer } = req.body;
-      const reqSchema = { id, answer };
+      const userId = req.user?.id;
+
+      const {questionId, answer } = req.body;
+      const reqSchema = { questionId, answer, userId };
 
       const validatedData = await validateDTOAnswerQuestion(reqSchema, res);
       if(!validatedData) return;
 
-      const dto = new AnswerQuestionDTO(validatedData.id, validatedData.answer);
+      const dto = new AnswerQuestionDTO(validatedData.questionId, validatedData.answer, validatedData.userId);
 
       const answerQuestion = await this.answerQuestionUseCase.execute(dto);
 


### PR DESCRIPTION
FIX da funcionalidade de **Responder Questão**:

-> Antes estava implementada sem persistir o progresso de questão do usuário

## Como testar

PUT /users/atualizarUsuario

```json

{
  "questionId": "Q-7d14117d-28d",
  "answer": "A"
}

```
---

## 🔜 Próximos Passos

- [ ] Adicionar testes unitários;  
